### PR TITLE
chore: update signature check logic

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -15,7 +15,7 @@ jobs:
 
           # Download the trusted keyring from nodejs/release-keys
           # https://github.com/nodejs/node#verifying-binaries
-          curl -fsLo "nodejs-keyring.kbx" "https://github.com/nodejs/release-keys/raw/HEAD/gpg/pubring.kbx"
+          curl -fsLo "/tmp/nodejs-keyring.kbx" "https://github.com/nodejs/release-keys/raw/HEAD/gpg/pubring.kbx"
 
           curl --no-progress-meter -O https://nodejs.org/dist/index.json
 
@@ -39,7 +39,7 @@ jobs:
 
             curl --no-progress-meter -O https://nodejs.org/dist/$version/SHASUMS256.txt.asc
 
-            if ! gpgv --keyring="nodejs-keyring.kbx" --output SHASUMS256.txt < SHASUMS256.txt.asc; then
+            if ! gpgv --keyring="/tmp/nodejs-keyring.kbx" --output SHASUMS256.txt < SHASUMS256.txt.asc; then
               echo "Skipping $version since signature verification failed"
               continue
             fi

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -46,6 +46,11 @@ jobs:
 
             files="SHASUMS256.txt SHASUMS256.txt.asc"
             while read -r line; do
+              # Skip empty lines
+              if [[ -z "$line" ]]; then
+                continue
+              fi
+
               hash=$(echo $line | cut -d ' ' -f 1)
               file=$(echo $line | cut -d ' ' -f 2)
 

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -13,20 +13,9 @@ jobs:
       - run: |
           set -e
 
-          # https://github.com/nodejs/node#release-keys
-          gpg --keyserver hkps://keys.openpgp.org --recv-keys \
-            4ED778F539E3634C779C87C6D7062848A1AB005C \
-            141F07595B7B3FFE74309A937405533BE57C7D57 \
-            74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-            DD792F5973C6DE52C432CBDAC77ABFA00DDBF2B7 \
-            CC68F5A3106FF448322E48ED27F5E38D5B0A215F \
-            8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-            C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-            890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
-            C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-            108F52B48DB57BB0CC439B2997B01419BD92F80A \
-            C0D6248439F1D5604AAFFB4021D900FFDB233756 \
-            A363A499291CBBC940DD62E41F10027AF002F8B0
+          # Download the trusted keyring from nodejs/release-keys
+          # https://github.com/nodejs/node#verifying-binaries
+          curl -fsLo "nodejs-keyring.kbx" "https://github.com/nodejs/release-keys/raw/HEAD/gpg/pubring.kbx"
 
           curl --no-progress-meter -O https://nodejs.org/dist/index.json
 
@@ -48,15 +37,14 @@ jobs:
             mkdir -p $version
             pushd $version
 
-            curl --no-progress-meter -O https://nodejs.org/dist/$version/SHASUMS256.txt
-            curl --no-progress-meter -O https://nodejs.org/dist/$version/SHASUMS256.txt.sig
+            curl --no-progress-meter -O https://nodejs.org/dist/$version/SHASUMS256.txt.asc
 
-            if ! gpg --verify SHASUMS256.txt.sig SHASUMS256.txt; then
+            if ! gpgv --keyring="nodejs-keyring.kbx" --output SHASUMS256.txt < SHASUMS256.txt.asc; then
               echo "Skipping $version since signature verification failed"
               continue
             fi
 
-            files="SHASUMS256.txt SHASUMS256.txt.sig"
+            files="SHASUMS256.txt SHASUMS256.txt.asc"
             while read -r line; do
               hash=$(echo $line | cut -d ' ' -f 1)
               file=$(echo $line | cut -d ' ' -f 2)

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -23,7 +23,7 @@ jobs:
           const fs = require('fs');
           const builds = JSON.parse(fs.readFileSync('index.json', 'utf8'));
           const versions = builds.map(build => build.version)
-            .filter(version => parseInt(/^v(\d+)\./.exec(version)[1]) >= 18);
+            .filter(version => parseInt(/^v(\d+)\./.exec(version)[1]) >= 20);
           console.log(versions.join('\n'));
           EOF
           )


### PR DESCRIPTION
Removes hard coded keys in favor of obtaining them from the public github repo. Additionally, the SHASUM256.txt is now extracted from the verified `SHASUM256.asc` file instead of downloading it separately.